### PR TITLE
Add exp_id paths #48

### DIFF
--- a/autosubmitconfigparser/config/basicconfig.py
+++ b/autosubmitconfigparser/config/basicconfig.py
@@ -72,22 +72,22 @@ class BasicConfig:
     DATABASE_CONN_URL = ""
 
     @staticmethod
-    def EXPID_DIR(exp_id):
-        if not isinstance(exp_id, str) or len(exp_id) != 4:
-            raise TypeError("Experiment ID must be a string of 4 characters")
+    def expid_dir(exp_id):
+        if not isinstance(exp_id, str) or len(exp_id) != 4 or "/" in exp_id:
+            raise TypeError("Experiment ID must be a string of 4 characters without the folder separator symbol")
         return os.path.join(BasicConfig.LOCAL_ROOT_DIR, exp_id)
 
     @staticmethod
-    def EXPID_TMP_DIR(exp_id):
-        return os.path.join(BasicConfig.EXPID_DIR(exp_id), BasicConfig.LOCAL_TMP_DIR) 
+    def expid_tmp_dir(exp_id):
+        return os.path.join(BasicConfig.expid_dir(exp_id), BasicConfig.LOCAL_TMP_DIR) 
 
     @staticmethod
-    def EXPID_LOG_DIR(exp_id):
-        return os.path.join(BasicConfig.EXPID_TMP_DIR(exp_id), f'LOG_{exp_id}')
+    def expid_log_dir(exp_id):
+        return os.path.join(BasicConfig.expid_tmp_dir(exp_id), f'LOG_{exp_id}')
 
     @staticmethod
-    def EXPID_ASLOG_DIR(exp_id):
-        return os.path.join(BasicConfig.EXPID_TMP_DIR(exp_id), BasicConfig.LOCAL_ASLOG_DIR)
+    def expid_aslog_dir(exp_id):
+        return os.path.join(BasicConfig.expid_tmp_dir(exp_id), BasicConfig.LOCAL_ASLOG_DIR)
     
     @staticmethod
     def _update_config():

--- a/autosubmitconfigparser/config/basicconfig.py
+++ b/autosubmitconfigparser/config/basicconfig.py
@@ -23,7 +23,6 @@ except ImportError:
     # noinspection PyCompatibility
     from configparser import ConfigParser as SafeConfigParser
 import os
-from pathlib import Path
 import inspect
 
 
@@ -76,19 +75,19 @@ class BasicConfig:
     def EXPID_DIR(exp_id):
         if not isinstance(exp_id, str) or len(exp_id) != 4:
             raise TypeError("Experiment ID must be a string of 4 characters")
-        return Path(BasicConfig.LOCAL_ROOT_DIR, exp_id)
+        return os.path.join(BasicConfig.LOCAL_ROOT_DIR, exp_id)
 
     @staticmethod
     def EXPID_TMP_DIR(exp_id):
-        return BasicConfig.EXPID_DIR(exp_id) / BasicConfig.LOCAL_TMP_DIR 
+        return os.path.join(BasicConfig.EXPID_DIR(exp_id), BasicConfig.LOCAL_TMP_DIR) 
 
     @staticmethod
     def EXPID_LOG_DIR(exp_id):
-        return BasicConfig.EXPID_TMP_DIR(exp_id) / f'LOG_{exp_id}'
+        return os.path.join(BasicConfig.EXPID_TMP_DIR(exp_id), f'LOG_{exp_id}')
 
     @staticmethod
     def EXPID_ASLOG_DIR(exp_id):
-        return BasicConfig.EXPID_TMP_DIR(exp_id) / BasicConfig.LOCAL_ASLOG_DIR 
+        return os.path.join(BasicConfig.EXPID_TMP_DIR(exp_id), BasicConfig.LOCAL_ASLOG_DIR)
     
     @staticmethod
     def _update_config():

--- a/autosubmitconfigparser/config/basicconfig.py
+++ b/autosubmitconfigparser/config/basicconfig.py
@@ -23,7 +23,7 @@ except ImportError:
     # noinspection PyCompatibility
     from configparser import ConfigParser as SafeConfigParser
 import os
-
+from pathlib import Path
 import inspect
 
 
@@ -72,6 +72,24 @@ class BasicConfig:
     DATABASE_BACKEND = "sqlite"
     DATABASE_CONN_URL = ""
 
+    @staticmethod
+    def EXPID_DIR(exp_id):
+        if not isinstance(exp_id, str) or len(exp_id) != 4:
+            raise TypeError("Experiment ID must be a string of 4 characters")
+        return Path(BasicConfig.LOCAL_ROOT_DIR, exp_id)
+
+    @staticmethod
+    def EXPID_TMP_DIR(exp_id):
+        return BasicConfig.EXPID_DIR(exp_id) / BasicConfig.LOCAL_TMP_DIR 
+
+    @staticmethod
+    def EXPID_LOG_DIR(exp_id):
+        return BasicConfig.EXPID_TMP_DIR(exp_id) / f'LOG_{exp_id}'
+
+    @staticmethod
+    def EXPID_ASLOG_DIR(exp_id):
+        return BasicConfig.EXPID_TMP_DIR(exp_id) / BasicConfig.LOCAL_ASLOG_DIR 
+    
     @staticmethod
     def _update_config():
         """

--- a/test/unit/test_basicconfig.py
+++ b/test/unit/test_basicconfig.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from autosubmitconfigparser.config.basicconfig import BasicConfig
+from conftest import autosubmit_config
 
 def test_read_file_config(tmp_path):
     config_content = """
@@ -21,36 +22,20 @@ def test_invalid_expid_path():
         for expid in invalid_expids:
             BasicConfig.expid_dir(expid)
 
-@pytest.fixture
-def temp_dir_expid(tmp_path):
-    # Create directory structure as Autosubmit.expid does
-    BasicConfig.LOCAL_ROOT_DIR = tmp_path 
-    exp_id = "a000"
-    exp_folder = os.path.join(tmp_path, exp_id)
-    os.mkdir(exp_folder)
-    os.mkdir(os.path.join(exp_folder, "conf"))
-    os.mkdir(os.path.join(exp_folder, "pkl"))
-    os.mkdir(os.path.join(exp_folder, "tmp"))
-    os.mkdir(os.path.join(exp_folder, "tmp", "ASLOGS"))
-    os.mkdir(os.path.join(exp_folder, "tmp", "LOG_"+exp_id))
-    os.mkdir(os.path.join(exp_folder, "plot"))
-    os.mkdir(os.path.join(exp_folder, "status"))
-    # end Autosubmit.expid
-    return tmp_path, exp_id
-
 functions_expid = [BasicConfig.expid_dir,
                    BasicConfig.expid_tmp_dir,
                    BasicConfig.expid_log_dir,
                    BasicConfig.expid_aslog_dir]
 root_dirs = [
-    lambda root_path, exp_id: str(root_path / exp_id),
-    lambda root_path, exp_id: str(root_path / exp_id / "tmp"),
-    lambda root_path, exp_id: str(root_path / exp_id / "tmp" / f"LOG_{exp_id}"),
-    lambda root_path, exp_id: str(root_path / exp_id / "tmp" / "ASLOGS")
+    lambda root_path, exp_id: os.path.join(root_path, exp_id),
+    lambda root_path, exp_id: os.path.join(root_path, exp_id, "tmp"),
+    lambda root_path, exp_id: os.path.join(root_path, exp_id, "tmp", f"LOG_{exp_id}"),
+    lambda root_path, exp_id: os.path.join(root_path, exp_id, "tmp", "ASLOGS")
 ]
 @pytest.mark.parametrize("foo, dir_func", zip(functions_expid, root_dirs))
-def test_expid_dir_structure(foo, dir_func, temp_dir_expid):
-    root_path, exp_id = temp_dir_expid
+def test_expid_dir_structure(foo, dir_func, autosubmit_config):
+    exp_id = 'a000'
+    root_path = autosubmit_config(expid = exp_id).basic_config.LOCAL_ROOT_DIR
     expected_path = dir_func(root_path, exp_id)
     result = foo(exp_id)
     assert result == expected_path

--- a/test/unit/test_basicconfig.py
+++ b/test/unit/test_basicconfig.py
@@ -17,7 +17,7 @@ def test_read_file_config(tmp_path):
 def test_invalid_expid_path():
     invalid_expids = ["", "12345", "123/", 1234] # empty, more than 4 char, contains folder separator, not string
 
-    with pytest.raises(Exception) as e_info:
+    with pytest.raises(Exception):
         for expid in invalid_expids:
             BasicConfig.expid_dir(expid)
 

--- a/test/unit/test_basicconfig.py
+++ b/test/unit/test_basicconfig.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 from autosubmitconfigparser.config.basicconfig import BasicConfig
-from conftest import autosubmit_config
 
 def test_read_file_config(tmp_path):
     config_content = """
@@ -33,7 +32,7 @@ root_dirs = [
     lambda root_path, exp_id: os.path.join(root_path, exp_id, "tmp", "ASLOGS")
 ]
 @pytest.mark.parametrize("foo, dir_func", zip(functions_expid, root_dirs))
-def test_expid_dir_structure(foo, dir_func):
+def test_expid_dir_structure(foo, dir_func, autosubmit_config):
     exp_id = 'a000'
     root_path = autosubmit_config(expid = exp_id).basic_config.LOCAL_ROOT_DIR
     expected_path = dir_func(root_path, exp_id)

--- a/test/unit/test_basicconfig.py
+++ b/test/unit/test_basicconfig.py
@@ -33,7 +33,7 @@ root_dirs = [
     lambda root_path, exp_id: os.path.join(root_path, exp_id, "tmp", "ASLOGS")
 ]
 @pytest.mark.parametrize("foo, dir_func", zip(functions_expid, root_dirs))
-def test_expid_dir_structure(foo, dir_func, autosubmit_config):
+def test_expid_dir_structure(foo, dir_func):
     exp_id = 'a000'
     root_path = autosubmit_config(expid = exp_id).basic_config.LOCAL_ROOT_DIR
     expected_path = dir_func(root_path, exp_id)

--- a/test/unit/test_basicconfig.py
+++ b/test/unit/test_basicconfig.py
@@ -1,7 +1,6 @@
 import os
-
+import pytest
 from autosubmitconfigparser.config.basicconfig import BasicConfig
-
 
 def test_read_file_config(tmp_path):
     config_content = """
@@ -14,3 +13,44 @@ def test_read_file_config(tmp_path):
     os.environ = {'AUTOSUBMIT_CONFIGURATION': str(config_file)}
     BasicConfig.read()
     assert BasicConfig.LOG_RECOVERY_TIMEOUT == 45
+
+def test_invalid_expid_path():
+    invalid_expids = ["", "12345", "123/", 1234] # empty, more than 4 char, contains folder separator, not string
+
+    with pytest.raises(Exception) as e_info:
+        for expid in invalid_expids:
+            BasicConfig.expid_dir(expid)
+
+@pytest.fixture
+def temp_dir_expid(tmp_path):
+    # Create directory structure as Autosubmit.expid does
+    BasicConfig.LOCAL_ROOT_DIR = tmp_path 
+    exp_id = "a000"
+    exp_folder = os.path.join(tmp_path, exp_id)
+    os.mkdir(exp_folder)
+    os.mkdir(os.path.join(exp_folder, "conf"))
+    os.mkdir(os.path.join(exp_folder, "pkl"))
+    os.mkdir(os.path.join(exp_folder, "tmp"))
+    os.mkdir(os.path.join(exp_folder, "tmp", "ASLOGS"))
+    os.mkdir(os.path.join(exp_folder, "tmp", "LOG_"+exp_id))
+    os.mkdir(os.path.join(exp_folder, "plot"))
+    os.mkdir(os.path.join(exp_folder, "status"))
+    # end Autosubmit.expid
+    return tmp_path, exp_id
+
+functions_expid = [BasicConfig.expid_dir,
+                   BasicConfig.expid_tmp_dir,
+                   BasicConfig.expid_log_dir,
+                   BasicConfig.expid_aslog_dir]
+root_dirs = [
+    lambda root_path, exp_id: str(root_path / exp_id),
+    lambda root_path, exp_id: str(root_path / exp_id / "tmp"),
+    lambda root_path, exp_id: str(root_path / exp_id / "tmp" / f"LOG_{exp_id}"),
+    lambda root_path, exp_id: str(root_path / exp_id / "tmp" / "ASLOGS")
+]
+@pytest.mark.parametrize("foo, dir_func", zip(functions_expid, root_dirs))
+def test_expid_dir_structure(foo, dir_func, temp_dir_expid):
+    root_path, exp_id = temp_dir_expid
+    expected_path = dir_func(root_path, exp_id)
+    result = foo(exp_id)
+    assert result == expected_path


### PR DESCRIPTION
Added functions in BasicConfig to return commonly used paths that includ exp_id; `EXPID_DIR`, `EXPID_TMP_DIR`, `EXPID_LOG_DIR` and `EXPID_ASLOG_DIR`