### PR TITLE
Quickfix Switch os.path to Path

### DIFF
--- a/autosubmitconfigparser/config/basicconfig.py
+++ b/autosubmitconfigparser/config/basicconfig.py
@@ -23,6 +23,7 @@ except ImportError:
     # noinspection PyCompatibility
     from configparser import ConfigParser as SafeConfigParser
 import os
+from pathlib import Path
 import inspect
 
 
@@ -75,19 +76,19 @@ class BasicConfig:
     def expid_dir(exp_id):
         if not isinstance(exp_id, str) or len(exp_id) != 4 or "/" in exp_id:
             raise TypeError("Experiment ID must be a string of 4 characters without the folder separator symbol")
-        return os.path.join(BasicConfig.LOCAL_ROOT_DIR, exp_id)
+        return Path(BasicConfig.LOCAL_ROOT_DIR).joinpath(exp_id)
 
     @staticmethod
     def expid_tmp_dir(exp_id):
-        return os.path.join(BasicConfig.expid_dir(exp_id), BasicConfig.LOCAL_TMP_DIR) 
+        return BasicConfig.expid_dir(exp_id).joinpath(BasicConfig.LOCAL_TMP_DIR) 
 
     @staticmethod
     def expid_log_dir(exp_id):
-        return os.path.join(BasicConfig.expid_tmp_dir(exp_id), f'LOG_{exp_id}')
+        return BasicConfig.expid_tmp_dir(exp_id).joinpath(f'LOG_{exp_id}')
 
     @staticmethod
     def expid_aslog_dir(exp_id):
-        return os.path.join(BasicConfig.expid_tmp_dir(exp_id), BasicConfig.LOCAL_ASLOG_DIR)
+        return BasicConfig.expid_tmp_dir(exp_id).joinpath(BasicConfig.LOCAL_ASLOG_DIR)
     
     @staticmethod
     def _update_config():

--- a/autosubmitconfigparser/config/basicconfig.py
+++ b/autosubmitconfigparser/config/basicconfig.py
@@ -76,7 +76,7 @@ class BasicConfig:
     def expid_dir(exp_id):
         if not isinstance(exp_id, str) or len(exp_id) != 4 or "/" in exp_id:
             raise TypeError("Experiment ID must be a string of 4 characters without the folder separator symbol")
-        return Path(BasicConfig.LOCAL_ROOT_DIR).joinpath(exp_id)
+        return Path(BasicConfig.LOCAL_ROOT_DIR, exp_id)
 
     @staticmethod
     def expid_tmp_dir(exp_id):

--- a/test/unit/test_basicconfig.py
+++ b/test/unit/test_basicconfig.py
@@ -27,10 +27,10 @@ functions_expid = [BasicConfig.expid_dir,
                    BasicConfig.expid_log_dir,
                    BasicConfig.expid_aslog_dir]
 root_dirs = [
-    lambda root_path, exp_id: Path(root_path).joinpath(exp_id),
-    lambda root_path, exp_id: Path(root_path).joinpath(exp_id, "tmp"),
-    lambda root_path, exp_id: Path(root_path).joinpath(exp_id, "tmp", f"LOG_{exp_id}"),
-    lambda root_path, exp_id: Path(root_path).joinpath(exp_id, "tmp", "ASLOGS")
+    lambda root_path, exp_id: Path(root_path, exp_id),
+    lambda root_path, exp_id: Path(root_path, exp_id, "tmp"),
+    lambda root_path, exp_id: Path(root_path, exp_id, "tmp", f"LOG_{exp_id}"),
+    lambda root_path, exp_id: Path(root_path, exp_id, "tmp", "ASLOGS")
 ]
 @pytest.mark.parametrize("foo, dir_func", zip(functions_expid, root_dirs))
 def test_expid_dir_structure(foo, dir_func, autosubmit_config):

--- a/test/unit/test_basicconfig.py
+++ b/test/unit/test_basicconfig.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from autosubmitconfigparser.config.basicconfig import BasicConfig
+from pathlib import Path
 
 def test_read_file_config(tmp_path):
     config_content = """
@@ -26,10 +27,10 @@ functions_expid = [BasicConfig.expid_dir,
                    BasicConfig.expid_log_dir,
                    BasicConfig.expid_aslog_dir]
 root_dirs = [
-    lambda root_path, exp_id: os.path.join(root_path, exp_id),
-    lambda root_path, exp_id: os.path.join(root_path, exp_id, "tmp"),
-    lambda root_path, exp_id: os.path.join(root_path, exp_id, "tmp", f"LOG_{exp_id}"),
-    lambda root_path, exp_id: os.path.join(root_path, exp_id, "tmp", "ASLOGS")
+    lambda root_path, exp_id: Path(root_path).joinpath(exp_id),
+    lambda root_path, exp_id: Path(root_path).joinpath(exp_id, "tmp"),
+    lambda root_path, exp_id: Path(root_path).joinpath(exp_id, "tmp", f"LOG_{exp_id}"),
+    lambda root_path, exp_id: Path(root_path).joinpath(exp_id, "tmp", "ASLOGS")
 ]
 @pytest.mark.parametrize("foo, dir_func", zip(functions_expid, root_dirs))
 def test_expid_dir_structure(foo, dir_func, autosubmit_config):


### PR DESCRIPTION
Following suggestions on Autosubmit's MR [509](https://earth.bsc.es/gitlab/es/autosubmit/-/merge_requests/509#129d4ed3c5acafd36c9039bc210f3fffbb934031_63_69), we stich from `os.path` to `pathlib.Path`