### PR TITLE
Gl as1316 dependencies

### DIFF
--- a/autosubmitconfigparser/config/configcommon.py
+++ b/autosubmitconfigparser/config/configcommon.py
@@ -575,9 +575,22 @@ class AutosubmitConfig(object):
             if "ADDITIONAL_FILES" not in data_fixed["JOBS"][job] and must_exists:
                 data_fixed["JOBS"][job]["ADDITIONAL_FILES"] = []
 
-
     @staticmethod
     def _normalize_dependencies(dependencies: Union[str, dict]) -> dict:
+        """
+        Normalize the dependencies to a consistent format.
+
+        This function takes a string or dictionary of dependencies and normalizes them to a dictionary format.
+        If the input is a string, it splits the string by spaces and converts each dependency to uppercase.
+        If the input is a dictionary, it converts each dependency key to uppercase and processes the status.
+
+        Additionally, it checks if any final status is allowed, and if so, it sets the flag "ANY_FINAL_STATUS_IS_VALID".
+
+        :param dependencies: The dependencies to normalize, either as a string or a dictionary.
+        :type dependencies: Union[str, dict]
+        :return: A dictionary with normalized dependencies.
+        :rtype: dict
+        """
         aux_dependencies = {}
         if isinstance(dependencies, str):
             for dependency in dependencies.upper().split(" "):
@@ -589,7 +602,11 @@ class AutosubmitConfig(object):
                     dependency_data["STATUS"] = dependency_data["STATUS"].upper()
                     if dependency_data["STATUS"][-1] == "?":
                         dependency_data["STATUS"] = dependency_data["STATUS"][:-1]
-                        dependency_data["OPTIONAL"] = True
+                        dependency_data["ANY_FINAL_STATUS_IS_VALID"] = True
+                    elif dependency_data["STATUS"] not in ["READY", "DELAYED", "PREPARED", "SKIPPED", "FAILED", "COMPLETED"]:  # May change in future issues.
+                        dependency_data["ANY_FINAL_STATUS_IS_VALID"] = True
+                    else:
+                        dependency_data["ANY_FINAL_STATUS_IS_VALID"] = False
 
         return aux_dependencies
 

--- a/autosubmitconfigparser/config/configcommon.py
+++ b/autosubmitconfigparser/config/configcommon.py
@@ -575,6 +575,7 @@ class AutosubmitConfig(object):
             if "ADDITIONAL_FILES" not in data_fixed["JOBS"][job] and must_exists:
                 data_fixed["JOBS"][job]["ADDITIONAL_FILES"] = []
 
+
     @staticmethod
     def _normalize_dependencies(dependencies: Union[str, dict]) -> dict:
         aux_dependencies = {}
@@ -584,6 +585,12 @@ class AutosubmitConfig(object):
         elif isinstance(dependencies, dict):
             for dependency, dependency_data in dependencies.items():
                 aux_dependencies[dependency.upper()] = dependency_data
+                if type(dependency_data) is dict and dependency_data.get("STATUS", None):
+                    dependency_data["STATUS"] = dependency_data["STATUS"].upper()
+                    if dependency_data["STATUS"][-1] == "?":
+                        dependency_data["STATUS"] = dependency_data["STATUS"][:-1]
+                        dependency_data["OPTIONAL"] = True
+
         return aux_dependencies
 
     @staticmethod

--- a/test/regression/DestinE_workflows/a000/ref/experiment_data.yml
+++ b/test/regression/DestinE_workflows/a000/ref/experiment_data.yml
@@ -2146,6 +2146,7 @@ JOBS:
       DN-1: {}
       REMOTE_SETUP:
         STATUS: COMPLETED
+        ANY_FINAL_STATUS_IS_VALID: False
     FILE: templates/dn.sh
     PLATFORM: MARENOSTRUM5-login
     RETRIALS: 3

--- a/test/unit/test_normalize_variables.py
+++ b/test/unit/test_normalize_variables.py
@@ -237,6 +237,51 @@ import pytest
         True,
         id="file_yaml_list"
     ),
+    pytest.param(
+        {
+            "JOBS": {
+                "job1": {
+                    "FILE": "FILE1",
+                    "DEPENDENCIES": {
+                        "job2": {"STATUS": "FAILED"},
+                        "job3": {"STATUS": "FAILED?"},
+                        "job4": {"STATUS": "RUNNING"},
+                        "job5": {"STATUS": "COMPLETED"},
+                        "job6": {"STATUS": "SKIPPED"},
+                        "job7": {"STATUS": "READY"},
+                        "job8": {"STATUS": "DELAYED"},
+                        "job9": {"STATUS": "PREPARED"},
+                        "job10": {"STATUS": "QUEUING"},
+                        "job11": {"STATUS": "SUBMITTED"},
+                        "job12": {"STATUS": "HELD"},
+                    },
+                }
+            }
+        },
+        {
+            'JOBS': {
+                'JOB1': {
+                    'FILE': 'FILE1',
+                    'ADDITIONAL_FILES': [],
+                    'DEPENDENCIES': {
+                        'JOB2': {'STATUS': 'FAILED', 'ANY_FINAL_STATUS_IS_VALID': False},
+                        'JOB3': {'STATUS': 'FAILED', 'ANY_FINAL_STATUS_IS_VALID': True},
+                        'JOB4': {'STATUS': 'RUNNING', 'ANY_FINAL_STATUS_IS_VALID': True},
+                        'JOB5': {'STATUS': 'COMPLETED', 'ANY_FINAL_STATUS_IS_VALID': False},
+                        'JOB6': {'STATUS': 'SKIPPED', 'ANY_FINAL_STATUS_IS_VALID': False},
+                        'JOB7': {'STATUS': 'READY', 'ANY_FINAL_STATUS_IS_VALID': False},
+                        'JOB8': {'STATUS': 'DELAYED', 'ANY_FINAL_STATUS_IS_VALID': False},
+                        'JOB9': {'STATUS': 'PREPARED', 'ANY_FINAL_STATUS_IS_VALID': False},
+                        'JOB10': {'STATUS': 'QUEUING', 'ANY_FINAL_STATUS_IS_VALID': True},
+                        'JOB11': {'STATUS': 'SUBMITTED', 'ANY_FINAL_STATUS_IS_VALID': True},
+                        'JOB12': {'STATUS': 'HELD', 'ANY_FINAL_STATUS_IS_VALID': True},
+                    },
+                },
+            }
+        },
+        True,
+        id="dependencies_status"
+    ),
 ])
 def test_normalize_variables(autosubmit_config, data, expected_data, must_exists):
     as_conf = autosubmit_config(expid='t000', experiment_data=data)


### PR DESCRIPTION
This is necessary for the https://earth.bsc.es/gitlab/es/autosubmit/-/issues/1316, 

Having the following yaml set by the user:

```yaml
JOBS:
  JOB:
    DEPENDENCIES:
       A:
          Status: "failed?"
```

Divide the "status: failed?" (and normalize it ) into:

```yaml
JOBS:
  JOB:
    DEPENDENCIES:
       A:
          Status: "FAILED"
          ANY_FINAL_STATUS_IS_VALID: True
```
