### PR TITLE
Issue #2073 from the AS repository where due to the ruamel update to …

### DIFF
--- a/autosubmitconfigparser/config/configcommon.py
+++ b/autosubmitconfigparser/config/configcommon.py
@@ -30,7 +30,6 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Union, Any, Tuple, Dict
 
-import ruamel.yaml as yaml
 from ruamel.yaml import YAML
 from bscearth.utils.date import parse_date
 from configobj import ConfigObj

--- a/autosubmitconfigparser/config/configcommon.py
+++ b/autosubmitconfigparser/config/configcommon.py
@@ -2501,11 +2501,11 @@ class AutosubmitConfig(object):
 
     # based on https://github.com/cbirajdar/properties-to-yaml-converter/blob/master/properties_to_yaml.py
     @staticmethod
-    def ini_to_yaml(root_dir, ini_file):
+    def ini_to_yaml(root_dir: Path, ini_file: str) -> None:
         # Based on http://stackoverflow.com/a/3233356
-        def update_dict(original_dict, updated_dict):
+        def update_dict(original_dict: Dict, updated_dict: collections.abc.Mapping) -> Dict:
             for k, v in updated_dict.items():
-                if isinstance(v, collections.Mapping):
+                if isinstance(v, collections.abc.Mapping):
                     r = update_dict(original_dict.get(k, {}), v)
                     original_dict[k] = r
                 else:

--- a/autosubmitconfigparser/config/configcommon.py
+++ b/autosubmitconfigparser/config/configcommon.py
@@ -2556,7 +2556,8 @@ class AutosubmitConfig(object):
             final_dict = yaml_dict
             # Write resultant dictionary to the yaml file
         yaml_file = open(input_file, 'w', encoding=locale.getlocale()[1])
-        yaml.dump(final_dict, yaml_file, Dumper=yaml.RoundTripDumper)
+        yaml = YAML()
+        yaml.dump(final_dict, yaml_file)
         ini_file.rename(Path(root_dir, ini_file.stem + ".yml"))
 
     def get_notifications_crash(self):

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -217,7 +217,8 @@ def autosubmit_config(
 
     def finalizer() -> None:
         BasicConfig.LOCAL_ROOT_DIR = original_root_dir
-        rmtree(tmp_path)
+        if tmp_path and tmp_path.exists():
+            rmtree(tmp_path)
 
     request.addfinalizer(finalizer)
 

--- a/test/unit/test_configcommon.py
+++ b/test/unit/test_configcommon.py
@@ -1,6 +1,7 @@
 from typing import Callable
 from pathlib import Path
 import pytest
+import sys
 
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
 
@@ -124,3 +125,18 @@ def test_clean_dynamic_variables(autosubmit_config: Callable) -> None:
 
     assert len(as_conf.dynamic_variables) == 1
     assert 'jaspion_eats' in as_conf.dynamic_variables
+
+
+def test_yaml_deprecation_warning(autosubmit_config: Callable):
+
+    as_conf: AutosubmitConfig = autosubmit_config(expid='a000', experiment_data={})
+    as_conf_copy: AutosubmitConfig = autosubmit_config(expid='a001', experiment_data={})
+
+    expid = str(as_conf.expid)
+    expid_copy = str(as_conf_copy.expid)
+    db_path = Path.home() / 'autosubmit'
+    file_base = "conf/expdef_"+expid+".conf"
+    file_copied = "conf/expdef_"+expid_copy+".conf_AS_v3_backup"
+    file = open(db_path/expid/file_base, 'r')
+    expected = open(db_path/expid_copy/file_copied, 'r')
+    assert expected.read() == file.read()

--- a/test/unit/test_configcommon.py
+++ b/test/unit/test_configcommon.py
@@ -130,10 +130,10 @@ def test_clean_dynamic_variables(autosubmit_config: Callable) -> None:
 def test_yaml_deprecation_warning(tmp_path, autosubmit_config: Callable):
     """Test that the conversion from YAML to INI works as expected, without warnings.
 
-    +    Creates a dummy AS3 INI file, calls ``AutosubmitConfig.ini_to_yaml``, and
-    +    verifies that the YAML files exists and is not empty, and a backup file was
-    +    created. All without warnings being raised (i.e. they were suppressed).
-    +    """
+    Creates a dummy AS3 INI file, calls ``AutosubmitConfig.ini_to_yaml``, and
+    verifies that the YAML files exists and is not empty, and a backup file was
+    created. All without warnings being raised (i.e. they were suppressed).
+    """
 
     as_conf: AutosubmitConfig = autosubmit_config(expid='a000', experiment_data={})
     ini_file = tmp_path / 'a000_jobs.ini'
@@ -146,17 +146,10 @@ def test_yaml_deprecation_warning(tmp_path, autosubmit_config: Callable):
         f.flush()
     as_conf.ini_to_yaml(root_dir=tmp_path, ini_file=str(ini_file))
 
-    print(f'tmp_path: {tmp_path}')
-    with open(tmp_path / 'a000_jobs.ini_AS_v3_backup', 'r') as backup, open(tmp_path / 'a000_jobs.yml', 'r') as newYaml:
-        lines_backup = backup.readlines()
-        lines_newYaml = newYaml.readlines()
+    backup_file = Path(f'{ini_file}_AS_v3_backup')
+    assert backup_file.exists()
+    assert backup_file.stat().st_size > 0
 
-        valid = True
-        for line_backup, line_newYaml in zip(lines_backup[1:], lines_newYaml[2:]):
-            if line_backup.strip().split('=')[1] != line_newYaml.strip().split(':')[1]:
-                valid = False
-
-        if valid:
-            assert True
-        elif valid:
-            assert False
+    new_yaml_file = Path(ini_file.parent,ini_file.stem).with_suffix('.yml')
+    assert new_yaml_file.exists()
+    assert new_yaml_file.stat().st_size > 0

--- a/test/unit/test_configcommon.py
+++ b/test/unit/test_configcommon.py
@@ -1,7 +1,6 @@
 from typing import Callable
 from pathlib import Path
 import pytest
-import sys
 
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
 
@@ -132,11 +131,11 @@ def test_yaml_deprecation_warning(autosubmit_config: Callable):
     as_conf: AutosubmitConfig = autosubmit_config(expid='a000', experiment_data={})
     as_conf_copy: AutosubmitConfig = autosubmit_config(expid='a001', experiment_data={})
 
+    as_path = Path.home() / 'autosubmit'
     expid = str(as_conf.expid)
     expid_copy = str(as_conf_copy.expid)
-    db_path = Path.home() / 'autosubmit'
     file_base = "conf/expdef_"+expid+".conf"
     file_copied = "conf/expdef_"+expid_copy+".conf_AS_v3_backup"
-    file = open(db_path/expid/file_base, 'r')
-    expected = open(db_path/expid_copy/file_copied, 'r')
-    assert expected.read() == file.read()
+    expected = open(as_path/expid_copy/file_copied, 'r')
+    with open(as_path/expid/file_base, 'r') as file:
+        assert expected.read() == file.read()

--- a/test/unit/test_configcommon.py
+++ b/test/unit/test_configcommon.py
@@ -156,4 +156,7 @@ def test_yaml_deprecation_warning(tmp_path, autosubmit_config: Callable):
             if line_backup.strip().split('=')[1] != line_newYaml.strip().split(':')[1]:
                 valid = False
 
-    assert valid == True
+        if valid:
+            assert True
+        elif valid:
+            assert False


### PR DESCRIPTION
First part of the solution for the issue https://github.com/BSC-ES/autosubmit/issues/2073 from the AS repository where due to the ruamel update to the version 0.18 A deprecated version of dump function was generating a warning when cloning a project from AS3 to the new AS4