### PR TITLE
Improve KeyError messages

### DIFF
--- a/autosubmitconfigparser/config/configcommon.py
+++ b/autosubmitconfigparser/config/configcommon.py
@@ -75,12 +75,28 @@ class AutosubmitConfig(object):
         self.misc_data = list()
 
     @property
-    def jobs_data(self):
-        return self.experiment_data["JOBS"]
+    def jobs_data(self) -> Dict[str, Any]:
+        try:
+            return self.experiment_data["JOBS"]
+        except KeyError:
+            raise AutosubmitCritical(
+                "JOBS section not found in configuration file", 7014
+            )
+        except Exception as exc:
+            raise AutosubmitCritical(f"Error while reading JOBS section: {exc}", 7014)
 
     @property
-    def platforms_data(self):
-        return self.experiment_data["PLATFORMS"]
+    def platforms_data(self) -> Dict[str, Any]:
+        try:
+            return self.experiment_data["PLATFORMS"]
+        except KeyError:
+            raise AutosubmitCritical(
+                "PLATFORMS section not found in configuration file", 7014
+            )
+        except Exception as exc:
+            raise AutosubmitCritical(
+                f"Error while reading PLATFORMS section: {exc}", 7014
+            )
 
     def get_wrapper_export(self, wrapper={}):
         """
@@ -2400,14 +2416,23 @@ class AutosubmitConfig(object):
 
         return str(self.get_section(['RERUN', 'RERUN'])).lower()
 
-    def get_platform(self):
+    def get_platform(self) -> str:
         """
         Returns main platforms from experiment's config file
 
         :return: main platforms
         :rtype: str
         """
-        return self.experiment_data['DEFAULT']['HPCARCH'].upper()
+        try:
+            return self.experiment_data["DEFAULT"]["HPCARCH"].upper()
+        except KeyError:
+            raise AutosubmitCritical(
+                "Defaul HPCARCH not defined in the configuration file", 7014
+            )
+        except Exception as exc:
+            raise AutosubmitCritical(
+                f"Error while reading HPCARCH from the configuration file: {exc}", 7014
+            )
 
     def set_platform(self, hpc):
         """

--- a/test/unit/test_configcommon.py
+++ b/test/unit/test_configcommon.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 import pytest
 
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
+from log.log import AutosubmitCritical
 
 """Basic tests for ``AutosubmitConfig``."""
 
@@ -153,3 +154,18 @@ def test_yaml_deprecation_warning(tmp_path, autosubmit_config: Callable):
     new_yaml_file = Path(ini_file.parent,ini_file.stem).with_suffix('.yml')
     assert new_yaml_file.exists()
     assert new_yaml_file.stat().st_size > 0
+
+
+def test_key_error_raise(autosubmit_config: Callable):
+    """Test that a KeyError is raised when a key is not found in the configuration."""
+    as_conf: AutosubmitConfig = autosubmit_config(expid="a000", experiment_data={})
+    with pytest.raises(AutosubmitCritical):
+        as_conf.jobs_data
+
+    with pytest.raises(AutosubmitCritical):
+        as_conf.platforms_data
+
+    as_conf.experiment_data = {"JOBS": {"SIM": {}}, "PLATFORMS": {"LOCAL": {}}}
+
+    assert as_conf.jobs_data == {"SIM": {}}
+    assert as_conf.platforms_data == {"LOCAL": {}}

--- a/test/unit/test_configcommon.py
+++ b/test/unit/test_configcommon.py
@@ -165,7 +165,15 @@ def test_key_error_raise(autosubmit_config: Callable):
     with pytest.raises(AutosubmitCritical):
         as_conf.platforms_data
 
-    as_conf.experiment_data = {"JOBS": {"SIM": {}}, "PLATFORMS": {"LOCAL": {}}}
+    with pytest.raises(AutosubmitCritical):
+        as_conf.get_platform()
+
+    as_conf.experiment_data = {
+        "JOBS": {"SIM": {}},
+        "PLATFORMS": {"LOCAL": {}},
+        "DEFAULT": {"HPCARCH": "DUMMY"},
+    }
 
     assert as_conf.jobs_data == {"SIM": {}}
     assert as_conf.platforms_data == {"LOCAL": {}}
+    assert as_conf.get_platform() == "DUMMY"


### PR DESCRIPTION
Related to what is shown in issue https://github.com/BSC-ES/autosubmit-api/issues/173

The purpose of this PR is to give better feedback to the API and Autosubmit when this error happens due to a key that is missing in a dictionary

Changed:

- `jobs_data() -> dict` property
- `platforms_data() -> dict` property
- `get_platform() -> str` method