### PR TITLE
Added metadata folder generation on save

### DIFF
--- a/autosubmitconfigparser/config/configcommon.py
+++ b/autosubmitconfigparser/config/configcommon.py
@@ -627,7 +627,8 @@ class AutosubmitConfig(object):
             wallclock = data_fixed["JOBS"][job].get("WALLCLOCK", "")
             if wallclock and re.match(r'^\d{2}:\d{2}:\d{2}$', wallclock):
                 # Truncate SS to "HH:MM"
-                Log.warning(f"Wallclock {wallclock} is in HH:MM:SS format. Autosubmit doesn't suppport ( yet ) the seconds. Truncating to HH:MM")
+                Log.warning(
+                    f"Wallclock {wallclock} is in HH:MM:SS format. Autosubmit doesn't suppport ( yet ) the seconds. Truncating to HH:MM")
                 data_fixed["JOBS"][job]["WALLCLOCK"] = wallclock[:5]
 
     @staticmethod
@@ -715,7 +716,8 @@ class AutosubmitConfig(object):
         # load yaml file with ruamel.yaml
 
         new_file = AutosubmitConfig.get_parser(self.parser_factory, yaml_file)
-        new_file.data = self.normalize_variables(new_file.data.copy(), must_exists=False)  # TODO Figure out why this .copy is needed
+        new_file.data = self.normalize_variables(new_file.data.copy(),
+                                                 must_exists=False)  # TODO Figure out why this .copy is needed
         if new_file.data.get("DEFAULT", {}).get("CUSTOM_CONFIG", None) is not None:
             new_file.data["DEFAULT"]["CUSTOM_CONFIG"] = self.convert_list_to_string(
                 new_file.data["DEFAULT"]["CUSTOM_CONFIG"])
@@ -1878,7 +1880,6 @@ class AutosubmitConfig(object):
                 self.data_changed = True
                 self.last_experiment_data = {}
 
-
     def detailed_deep_diff(self, current_data, last_run_data, level=0):
         """
         Returns a dictionary with for each key, the difference between the current configuration and the last_run_data
@@ -1995,7 +1996,6 @@ class AutosubmitConfig(object):
         :rtype: dict
         """
         return self.deep_parameters_export(self.experiment_data, self.default_parameters)
-
 
     def load_platform_parameters(self):
         """

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -7,7 +7,7 @@ import pytest
 
 from autosubmitconfigparser.config.basicconfig import BasicConfig
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
-
+from py.path import local as LocalPath
 if TYPE_CHECKING:
     import pytest_mock
 
@@ -171,7 +171,8 @@ def as_conf_large(autosubmit_config: AutosubmitConfigFactory) -> AutosubmitConfi
 @pytest.fixture(scope="function")
 def autosubmit_config(
         request: pytest.FixtureRequest,
-        mocker: "pytest_mock.MockerFixture") -> AutosubmitConfigFactory:
+        mocker: "pytest_mock.MockerFixture",
+        tmpdir: "LocalPath") -> AutosubmitConfigFactory:
     """Return a factory for ``AutosubmitConfig`` objects.
 
     Abstracts the necessary mocking in ``AutosubmitConfig`` and related objects,
@@ -184,8 +185,8 @@ def autosubmit_config(
     """
 
     original_root_dir = BasicConfig.LOCAL_ROOT_DIR
-    tmp_dir = TemporaryDirectory()
-    tmp_path = Path(tmp_dir.name)
+    tmp_dir = tmpdir
+    tmp_path = Path(tmp_dir)
 
     # Mock this as otherwise BasicConfig.read resets our other mocked values above.
     mocker.patch.object(BasicConfig, "read", autospec=True)

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from autosubmitconfigparser.config.basicconfig import BasicConfig
 from autosubmitconfigparser.config.configcommon import AutosubmitConfig
 from py.path import local as LocalPath
+
 if TYPE_CHECKING:
     import pytest_mock
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from shutil import rmtree
-from tempfile import TemporaryDirectory
 from typing import Any, Dict, Optional, Protocol, TYPE_CHECKING
 
 import pytest

--- a/test/unit/test_save.py
+++ b/test/unit/test_save.py
@@ -4,19 +4,16 @@ from ruamel.yaml import YAML
 
 
 @pytest.mark.parametrize("data", [
-    pytest.param(
-        {
-            "DEFAULT": {
-                "HPCARCH": "local",
-            },
+    {
+        "DEFAULT": {
+            "HPCARCH": "local",
         },
-        id="save",
-    ),
-])
+    },
+], ids=["local"])
 def test_save(autosubmit_config, tmpdir, data, mocker):
+    data['ROOTDIR'] = tmpdir.strpath
+    data['AS_ENV_CURRENT_USER'] = Path(tmpdir).owner()
     as_conf = autosubmit_config(expid='t000', experiment_data=data)
-    as_conf.metadata_folder = tmpdir / 'metadata'
-    Path(as_conf.metadata_folder).mkdir(parents=True, exist_ok=True)
     as_conf.save()
     assert Path(as_conf.metadata_folder) / 'experiment_data.yml' in Path(as_conf.metadata_folder).iterdir()
     # check contents

--- a/test/unit/test_save.py
+++ b/test/unit/test_save.py
@@ -2,33 +2,50 @@ import pytest
 from pathlib import Path
 from ruamel.yaml import YAML
 
+import pytest
+from pathlib import Path
+from ruamel.yaml import YAML
 
-@pytest.mark.parametrize("data", [
-    {
-        "DEFAULT": {
-            "HPCARCH": "local",
-        },
-    },
-], ids=["local"])
-def test_save(autosubmit_config, tmpdir, data, mocker):
+
+@pytest.mark.parametrize("data, owner", [
+    ({
+         "DEFAULT": {
+             "HPCARCH": "local",
+         },
+     }, True),
+    ({
+         "DEFAULT": {
+             "HPCARCH": "local",
+         },
+     }, False)
+], ids=["local_true", "local_false"])
+def test_save(autosubmit_config, tmpdir, mocker, data, owner):
     data['ROOTDIR'] = tmpdir.strpath
-    data['AS_ENV_CURRENT_USER'] = Path(tmpdir).owner()
+    if owner:
+        data['AS_ENV_CURRENT_USER'] = Path(tmpdir).owner()
+    else:
+        data['AS_ENV_CURRENT_USER'] = 'whatever'
     as_conf = autosubmit_config(expid='t000', experiment_data=data)
     as_conf.save()
-    assert Path(as_conf.metadata_folder) / 'experiment_data.yml' in Path(as_conf.metadata_folder).iterdir()
-    # check contents
-    with open(Path(as_conf.metadata_folder) / 'experiment_data.yml', 'r') as f:
-        yaml = YAML(typ="safe")
-        assert data == yaml.load(f)
+    if not owner:
+        assert not Path(as_conf.metadata_folder).exists()
+    else:
+        assert Path(as_conf.metadata_folder).exists()
+        assert Path(as_conf.metadata_folder) / 'experiment_data.yml' in Path(as_conf.metadata_folder).iterdir()
 
-    # Test .bak generated.
-    as_conf.save()
-    assert Path(as_conf.metadata_folder) / 'experiment_data.yml.bak' in Path(as_conf.metadata_folder).iterdir()
+        # check contents
+        with open(Path(as_conf.metadata_folder) / 'experiment_data.yml', 'r') as f:
+            yaml = YAML(typ="safe")
+            assert data == yaml.load(f)
 
-    # force fail save
-    mocker.patch("builtins.open", side_effect=Exception("Forced exception"))
-    mocker.patch("shutil.copyfile", return_value=True)
-    as_conf.save()
-    assert Path(as_conf.metadata_folder) / 'experiment_data.yml' not in Path(as_conf.metadata_folder).iterdir()
-    assert as_conf.data_changed is True
-    assert as_conf.last_experiment_data == {}
+        # Test .bak generated.
+        as_conf.save()
+        assert Path(as_conf.metadata_folder) / 'experiment_data.yml.bak' in Path(as_conf.metadata_folder).iterdir()
+
+        # force fail save
+        mocker.patch("builtins.open", side_effect=Exception("Forced exception"))
+        mocker.patch("shutil.copyfile", return_value=True)
+        as_conf.save()
+        assert Path(as_conf.metadata_folder) / 'experiment_data.yml' not in Path(as_conf.metadata_folder).iterdir()
+        assert as_conf.data_changed is True
+        assert as_conf.last_experiment_data == {}

--- a/test/unit/test_save.py
+++ b/test/unit/test_save.py
@@ -2,10 +2,6 @@ import pytest
 from pathlib import Path
 from ruamel.yaml import YAML
 
-import pytest
-from pathlib import Path
-from ruamel.yaml import YAML
-
 
 @pytest.mark.parametrize("data, owner", [
     ({

--- a/test/unit/test_save.py
+++ b/test/unit/test_save.py
@@ -27,7 +27,7 @@ def test_save(autosubmit_config, tmpdir, mocker, data, owner):
         assert not Path(as_conf.metadata_folder).exists()
     else:
         assert Path(as_conf.metadata_folder).exists()
-        assert Path(as_conf.metadata_folder) / 'experiment_data.yml' in Path(as_conf.metadata_folder).iterdir()
+        assert (Path(as_conf.metadata_folder) / 'experiment_data.yml').exists()
 
         # check contents
         with open(Path(as_conf.metadata_folder) / 'experiment_data.yml', 'r') as f:
@@ -36,8 +36,7 @@ def test_save(autosubmit_config, tmpdir, mocker, data, owner):
 
         # Test .bak generated.
         as_conf.save()
-        assert Path(as_conf.metadata_folder) / 'experiment_data.yml.bak' in Path(as_conf.metadata_folder).iterdir()
-
+        assert (Path(as_conf.metadata_folder) / 'experiment_data.yml.bak').exists()
         # force fail save
         mocker.patch("builtins.open", side_effect=Exception("Forced exception"))
         mocker.patch("shutil.copyfile", return_value=True)


### PR DESCRIPTION
* Added metadata folder generation on save()
* Changed save to do the save of experiment_data.yml only if you own the experiment. 

* Modified autosubmit_config fixture, to instead of calling a Temporally Directory, use the pytest fixture ( with this we ensure that tests using pytest.tmpdir and autosubmit_config uses the same root folder)

closes https://github.com/BSC-ES/autosubmit-config-parser/issues/77