### PR TITLE
escape deprecated in regex (\) -> (\\)

### DIFF
--- a/autosubmitconfigparser/config/configcommon.py
+++ b/autosubmitconfigparser/config/configcommon.py
@@ -626,7 +626,7 @@ class AutosubmitConfig(object):
         """
         for job in data_fixed.get("JOBS", {}):
             wallclock = data_fixed["JOBS"][job].get("WALLCLOCK", "")
-            if wallclock and re.match(r'^\d{2}:\d{2}:\d{2}$', wallclock):
+            if wallclock and re.match(r'^\\d{2}:\\d{2}:\\d{2}$', wallclock):
                 # Truncate SS to "HH:MM"
                 Log.warning(
                     f"Wallclock {wallclock} is in HH:MM:SS format. Autosubmit doesn't suppport ( yet ) the seconds. Truncating to HH:MM")
@@ -978,7 +978,7 @@ class AutosubmitConfig(object):
         if not in_the_end:
             return copy.deepcopy(self.dynamic_variables), '%[a-zA-Z0-9_.-]*%', 1
         else:
-            return copy.deepcopy(self.special_dynamic_variables), '%\^[a-zA-Z0-9_.-]*%', 2
+            return copy.deepcopy(self.special_dynamic_variables), '%\\^[a-zA-Z0-9_.-]*%', 2
 
     def _process_dynamic_variables(
             self,
@@ -1160,7 +1160,7 @@ class AutosubmitConfig(object):
             # Pattern to search a string starting with % and ending with % allowing the chars [],._ to exist in the middle
             dynamic_var_pattern = '%[a-zA-Z0-9_.-]*%'
             # Pattern to search a string starting with %^ and ending with %
-            special_dynamic_var_pattern = '%\^[a-zA-Z0-9_.-]*%'
+            special_dynamic_var_pattern = '%\\^[a-zA-Z0-9_.-]*%'
 
             if not isinstance(val, collections.abc.Mapping) and re.search(dynamic_var_pattern, str(val),
                                                                           flags=re.IGNORECASE) is not None:
@@ -2941,7 +2941,7 @@ class AutosubmitConfig(object):
 
     @staticmethod
     def is_valid_mail_address(mail_address):
-        if re.match('^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$', mail_address,
+        if re.match('^[_a-z0-9-]+(\\.[_a-z0-9-]+)*@[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,4})$', mail_address,
                     flags=re.IGNORECASE):
             return True
         else:


### PR DESCRIPTION
escape with only one \ gives a deprecated message needing to be used double inverted dash now (\)